### PR TITLE
Added a field to display Total number of projects an org has completed

### DIFF
--- a/src/components/org-card.css
+++ b/src/components/org-card.css
@@ -33,6 +33,11 @@
   font-family: "Galano Grotesque Alt Medium";
 }
 
+.org-card-project-count-container {
+  text-align: center;
+  padding: 2% 2%;
+}
+
 .org-card-description-container {
   padding: 2% 3%;
   font-family: "Galano Grotesque Alt Light";

--- a/src/components/org-card.jsx
+++ b/src/components/org-card.jsx
@@ -54,6 +54,9 @@ const OrgCard = ({ data }) => {
         ></div>
       </div>
       <div className="org-card-name-container">{data.name}</div>
+      <div className="org-card-project-count-container">
+        Total Projects: {data.totalProjects}
+      </div>
       <div className="org-card-category-container">
         <span>{data.category}</span>
       </div>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -21,11 +21,13 @@ import { urlChanged } from "../store/actions"
 const getOrganizations = data => {
   return data.allOrganization.edges.map(orgNode => {
     let org = orgNode.node
+    org.totalProjects = 0
     for (const yearKey of Object.keys(org.years)) {
       if (yearKey[0] === "_") {
         if (org.years[yearKey] !== null) {
           let year = yearKey.slice(1)
           org.years[year] = org.years[yearKey]
+          org.totalProjects += org.years[yearKey].num_projects
         }
         delete org.years[yearKey]
       }


### PR DESCRIPTION
Hi @nishantwrp,

When I was using the [Website](https://www.gsocorganizations.dev/), I thought it would be helpful for users who want to filter organizations based on number of projects. So, I added some changes to show the total number of projects an organization has completed so far.

I also think adding a sort functionality based on the total number of projects would help users in filtering down their org search for GSoC. Let me know what are your thoughts on this.

Thanks 