### PR TITLE
fix: add word-wrap to allow long words to break in project cards

### DIFF
--- a/src/components/project-card.css
+++ b/src/components/project-card.css
@@ -6,6 +6,7 @@
   height: 100%;
   margin: 0px auto;
   width: 100%;
+  word-wrap: break-word;
 }
 
 .project-card-link {
@@ -13,8 +14,8 @@
 }
 
 .ui.two.buttons {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: space-evenly;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
 }


### PR DESCRIPTION
- Adds `word-wrap: break-word` to allow long words to break.
- Lints `src/components/project-card.css` file
- Point your web browser at [Oppia | Projects](https://deploy-preview-133--gsoc-organizations.netlify.app/organization/oppia-foundation/) to view changes.