### PR TITLE
Fix notification text to reflect GSoC 2025 coding period

### DIFF
--- a/src/components/notification.jsx
+++ b/src/components/notification.jsx
@@ -10,7 +10,7 @@ const Notification = () => {
   return (
     <Message positive style={style}>
       <Message.Header>
-        Coding period for GSoC 2024 has started. You can check the program
+        Coding period for GSoC 2025 has started. You can check the program
         timeline{" "}
         <a
           href="https://developers.google.com/open-source/gsoc/timeline"


### PR DESCRIPTION
This pull request fixes a minor issue in the notification text displayed on the top of the page.  

#### **Problem**:  
Currently, the notification says:  
> "Coding period for GSoC 2024 has started. You can check the program timeline here."  
However, the coding period for GSoC 2025 has started, so the year needs to be updated to 2025.

#### **Solution**:  
The text has been updated in `src/components/notification.jsx` to reflect the correct year:  
> "Coding period for GSoC 2025 has started. You can check the program timeline here."

#### **Files Changed**:  
- `src/components/notification.jsx`

#### **Impact**:  
- This ensures users see accurate information about the current GSoC timeline.  

Let me know if further changes are required. 😊