### PR TITLE
fix: Updated GSoC banner and notification to 2025

### DIFF
--- a/src/components/notification.jsx
+++ b/src/components/notification.jsx
@@ -10,7 +10,7 @@ const Notification = () => {
   return (
     <Message positive style={style}>
       <Message.Header>
-        Coding period for GSoC 2024 has started. You can check the program
+        Coding period for GSoC 2025 has started. You can check the program
         timeline{" "}
         <a
           href="https://developers.google.com/open-source/gsoc/timeline"


### PR DESCRIPTION
This PR updates the GSoC banner and notification text for the year 2025 to keep the content up to date.

Changes Made:
✅ Updated the banner text from 2024 → 2025
✅ Modified the notification message accordingly

Why This Change?
🔹 Ensures the latest information is displayed
🔹 Maintains consistency with the current GSoC cycle

Testing & Validation:
✅ Manually verified the banner update
✅ Checked that the notification displays correctly