### PR TITLE
feat: if the link is missing removed button

### DIFF
--- a/src/components/project-card.css
+++ b/src/components/project-card.css
@@ -13,9 +13,14 @@
   margin: 1%;
 }
 
-.ui.two.buttons {
+.ui.two.buttons,
+.ui.one.buttons {
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-evenly;
+}
+
+.ui.one.buttons {
+  justify-content: center;
 }

--- a/src/components/project-card.jsx
+++ b/src/components/project-card.jsx
@@ -14,7 +14,11 @@ const ProjectCard = ({ data }) => {
           <Card.Description>{data.short_description}</Card.Description>
         </Card.Content>
         <Card.Content extra>
-          <div className="ui two buttons">
+          <div
+            className={`ui ${
+              data.code_url && data.code_url !== "" ? "two" : "one"
+            } buttons`}
+          >
             <OutboundLink
               className="project-card-link"
               href={data.project_url}
@@ -25,20 +29,18 @@ const ProjectCard = ({ data }) => {
                 More Details
               </Button>
             </OutboundLink>
-            <OutboundLink
-              className="project-card-link"
-              href={data.code_url}
-              target="_blank"
-              rel="noreferrer"
-            >
-              <Button
-                basic
-                color="orange"
-                disabled={!data.code_url || data.code_url === ""}
+            {data.code_url && data.code_url !== "" && (
+              <OutboundLink
+                className="project-card-link"
+                href={data.code_url}
+                target="_blank"
+                rel="noreferrer"
               >
-                Code Submission
-              </Button>
-            </OutboundLink>
+                <Button basic color="orange">
+                  Code Submission
+                </Button>
+              </OutboundLink>
+            )}
           </div>
         </Card.Content>
       </Card>


### PR DESCRIPTION
### Context
In the previous PR, @nishantwrp suggested exploring the option of removing the button altogether if the link is missing.  
Reference: [comment here](https://github.com/nishantwrp/gsoc-organizations/pull/159#pullrequestreview-2635682845).

### Changes
- Updated project-card component to hide button when no link is available.
- Adjusted CSS for proper spacing when button is absent.


<img width="960" height="480" alt="image" src="https://github.com/user-attachments/assets/987a9630-09f6-4eac-ace7-a7000515d2ad" />
