### PR TITLE
Added sorting based on project number feature

### DIFF
--- a/src/components/filters/sort.jsx
+++ b/src/components/filters/sort.jsx
@@ -1,0 +1,38 @@
+import React from "react"
+import { Dropdown } from "semantic-ui-react"
+import { useAppDispatch, useAppSelector } from "../../store"
+import { setSortBy } from "../../store/filters"
+
+const Sort = () => {
+  const dispatch = useAppDispatch()
+  const currentSort = useAppSelector(state => state.filters.sortBy)
+
+  const options = [
+    { key: 1, text: "Default", value: "" },
+    { key: 2, text: "Most Projects", value: "projects_desc" },
+    { key: 3, text: "Least Projects", value: "projects_asc" },
+  ]
+
+  const handleSortChange = (e, data) => {
+    dispatch(setSortBy(data.value))
+  }
+
+  return (
+    <div style={{ display: "flex", alignItems: "center" }}>
+      <span
+        style={{ marginRight: "8px", fontWeight: "bold", fontSize: "0.9em" }}
+      >
+        Sort by:
+      </span>
+      <Dropdown
+        selection
+        options={options}
+        value={currentSort}
+        onChange={handleSortChange}
+        placeholder="Select..."
+      />
+    </div>
+  )
+}
+
+export default Sort

--- a/src/store/filters.js
+++ b/src/store/filters.js
@@ -32,7 +32,10 @@ export const getFiltersFromSearchUrl = () => {
 
 const filtersSlice = createSlice({
   name: "filters",
-  initialState: () => getFiltersFromSearchUrl(),
+  initialState: () => ({
+    ...getFiltersFromSearchUrl(),
+    sortBy: getSearchParam("sort") || "",
+  }),
   reducers: {
     addFilter: (state, action) => {
       const { name, val } = action.payload
@@ -56,12 +59,25 @@ const filtersSlice = createSlice({
       }
       updateFiltersInUrl(state)
     },
+    setSortBy: (state, action) => {
+      state.sortBy = action.payload
+      if (action.payload) {
+        setSearchParams({ sort: action.payload })
+      } else {
+        removeSearchParam("sort")
+      }
+    },
   },
   extraReducers: builder => {
     builder.addCase(urlChanged, (state, action) => {
       const { filters } = action.payload
       ensureAllFilters(filters)
-      return { ...filters }
+      const newSortBy = getSearchParam("sort") || ""
+
+      for (const filter of FILTERS) {
+        state[filter] = filters[filter] || []
+      }
+      state.sortBy = newSortBy
     })
   },
 })
@@ -72,5 +88,5 @@ export const getFilters = state => {
 
 export const {
   reducer,
-  actions: { addFilter, removeFilter, setFilters, clearFilters },
+  actions: { addFilter, removeFilter, setFilters, clearFilters, setSortBy },
 } = filtersSlice


### PR DESCRIPTION
**Description**

This PR addresses #173 by introducing a new sorting option that enables users to order organisations by their total number of projects.

This sorting works seamlessly with all currently active filters (year, technology, category, etc.), allowing users first to filter down the list and then sort the remaining results by project count.

**Working Demo**
https://github.com/user-attachments/assets/2014435d-d9de-410d-8e17-f0393c967f90

