### PR TITLE
add: gsoc 2026 timeline

### DIFF
--- a/src/components/notification.jsx
+++ b/src/components/notification.jsx
@@ -10,7 +10,7 @@ const Notification = () => {
   return (
     <Message positive style={style}>
       <Message.Header>
-        Coding period for GSoC 2025 has started. You can check the program
+        Timeline for GSoC 2026 has been published. You can check the program
         timeline{" "}
         <a
           href="https://developers.google.com/open-source/gsoc/timeline"


### PR DESCRIPTION
Added GSoC 2026 timeline in notification.

Suggestion: Since the timeline link would be same, and each year we might have to change. So can we keep the text a bit generic of notification banner?

closes #190 